### PR TITLE
build: specify setuptools version

### DIFF
--- a/hinghwa-dict-backend/requirements.txt
+++ b/hinghwa-dict-backend/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==57.4.0
 django==3.1.14
 demjson
 pyjwt


### PR DESCRIPTION
在 58 以后的 setuptools 中，安装 demjson 会出现一些问题，所以必须指定一下 setuptools 的版本