### PR TITLE
fix(word): add new migrations due to version bumped

### DIFF
--- a/hinghwa-dict-backend/word/migrations/0008_alter_word_related_words.py
+++ b/hinghwa-dict-backend/word/migrations/0008_alter_word_related_words.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("word", "0007_character_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="word",
+            name="related_words",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="related_words",
+                to="word.word",
+                verbose_name="相关词汇",
+            ),
+        ),
+    ]


### PR DESCRIPTION
更新版本后，使用make migrations会产生新文件，可能是因为下面的warning:
![image](https://github.com/e-dialect/hinghwa-dict-backend/assets/111524029/dd5c084f-aaf2-440d-b925-4b85e726f81e)
