### PR TITLE
refactor: remove unused token assignments

### DIFF
--- a/hinghwa-dict-backend/article/views.py
+++ b/hinghwa-dict-backend/article/views.py
@@ -188,7 +188,7 @@ class ManageArticle(View):
         if not article.exists():
             raise ArticleNotFoundException()
         article = article[0]
-        token = token_pass(request.headers, article.author.id)
+        token_pass(request.headers, article.author.id)
         body = demjson3.decode(request.body)
         body = body["article"]
         article_form = ArticleForm(body)
@@ -216,7 +216,7 @@ class ManageArticle(View):
         if not article.exists():
             raise ArticleNotFoundException()
         article = article[0]
-        token = token_pass(request.headers, article.author.id)
+        token_pass(request.headers, article.author.id)
         article.delete()
         return JsonResponse({}, status=200)
 
@@ -224,7 +224,7 @@ class ManageArticle(View):
 class ManageVisibility(View):
     # AT0105 文章审核
     def put(self, request, id) -> JsonResponse:
-        token = token_pass(request.headers, -1)
+        token_pass(request.headers, -1)
         article = Article.objects.filter(id=id)
         if not article.exists():
             raise ArticleNotFoundException()

--- a/hinghwa-dict-backend/music/views.py
+++ b/hinghwa-dict-backend/music/views.py
@@ -72,7 +72,7 @@ class ManageMusic(View):
         if not music.exists():
             raise MusicNotFoundException()
         music = music[0]
-        token = token_pass(request.headers, music.contributor.id)
+        token_pass(request.headers, music.contributor.id)
         body = demjson3.decode(request.body)
         body = body["music"]
         music_form = MusicForm(body)
@@ -90,7 +90,7 @@ class ManageMusic(View):
         if not music.exists():
             raise MusicNotFoundException()
         music = music[0]
-        token = token_pass(request.headers, music.contributor.id)
+        token_pass(request.headers, music.contributor.id)
         music.delete()
         return JsonResponse({}, status=200)
 
@@ -124,7 +124,7 @@ class LikeMusic(View):
 class VisibilityMusic(View):
     # MC0105 设置音乐可见性
     def put(self, request, id) -> JsonResponse:
-        token = token_pass(request.headers, -1)
+        token_pass(request.headers, -1)
         music = Music.objects.filter(id=id)
         if not music.exists():
             raise MusicNotFoundException()

--- a/hinghwa-dict-backend/quiz/views.py
+++ b/hinghwa-dict-backend/quiz/views.py
@@ -137,7 +137,7 @@ class RandomQuiz(View):
 class ManageVisibility(View):
     # QZ0105 问题审核
     def put(self, request, id) -> JsonResponse:
-        token = token_pass(request.headers, -1)
+        token_pass(request.headers, -1)
         quiz = Quiz.objects.filter(id=id)
         if not quiz.exists():
             raise QuizNotFoundException()

--- a/hinghwa-dict-backend/rewards/products/views/Manage_all.py
+++ b/hinghwa-dict-backend/rewards/products/views/Manage_all.py
@@ -15,7 +15,7 @@ class ManageAllProducts(View):
     # RE0101 上传新商品
     @csrf_exempt
     def post(self, request) -> JsonResponse:
-        token = token_pass(request.headers, -1)
+        token_pass(request.headers, -1)
         body = demjson3.decode(request.body)
         products_form = ProductInfoForm(body)
         if not products_form.is_valid():

--- a/hinghwa-dict-backend/rewards/titles/views/Manage_all.py
+++ b/hinghwa-dict-backend/rewards/titles/views/Manage_all.py
@@ -39,7 +39,7 @@ class ManageAllTitles(View):
     # RE0201上传新头衔
     @csrf_exempt
     def post(self, request) -> JsonResponse:
-        token = token_pass(request.headers, -1)
+        token_pass(request.headers, -1)
         body = demjson3.decode(request.body)
         title_form = TitleInfoForm(body)
         if not title_form.is_valid():

--- a/hinghwa-dict-backend/word/word/views.py
+++ b/hinghwa-dict-backend/word/word/views.py
@@ -164,7 +164,7 @@ class ManageWord(View):
         if not word.exists:
             raise WordNotFoundException()
         word = word[0]
-        token = token_pass(request.headers, word.contributor.id)
+        token_pass(request.headers, word.contributor.id)
         body = demjson3.decode(request.body)
         body = body["word"]
         word_form = WordForm(body)
@@ -203,7 +203,7 @@ class ManageWord(View):
         if not word.exists:
             raise WordNotFoundException()
         word = word[0]
-        token = token_pass(request.headers, word.contributor.id)
+        token_pass(request.headers, word.contributor.id)
         item = re.split("[^a-z]", str(word.standard_pinyin))  # 去括号引号
         item = [x for x in item if x]
         PhoneticOrdering.root.delete(item, PhoneticOrdering.root.trie)


### PR DESCRIPTION
## Summary

- remove 11 unused local assignments of `token_pass(...)` return values
- keep every authentication and authorization call in its original position
- leave assignments that are consumed by `token_user(...)` or conditional logic unchanged

## Verification

- `git diff --check`
- `python3 -m py_compile` for all six changed modules
- audited all remaining `token = token_pass(...)` occurrences for actual use
- full Django tests were not run locally because the worktree has no project dependencies installed; GitHub e2e CI provides the repository's integration coverage

Closes #368
