### PR TITLE
build: fix Python dependency installation

### DIFF
--- a/hinghwa-dict-backend/requirements.txt
+++ b/hinghwa-dict-backend/requirements.txt
@@ -10,13 +10,13 @@ django-notifications-hq==1.8.3
 # Utilities
 demjson3~=3.0.6
 pyjwt~=2.4.0
-python-environ==0.4.54
+django-environ==0.14.0
 
 # Data Processing
 xlrd~=2.0.1
 numpy>=1.26.0,<2.0.0  # Python 3.12+ compatible, avoid numpy 2.x for compatibility
 requests
-requests_toolbelt==0.10.1
+requests_toolbelt==1.0.0
 
 # Audio Processing
 pydub==0.25.1
@@ -29,6 +29,7 @@ cos-python-sdk-v5
 
 # Job Scheduling
 apscheduler==3.7.0
+setuptools<81  # apscheduler 3.7 imports pkg_resources
 
 # Development Tools
 black==24.3.0


### PR DESCRIPTION
## Summary

- replace the unavailable `python-environ==0.4.54` requirement with the maintained `django-environ` distribution used by `HinghwaDict/settings.py`
- update `requests_toolbelt` for compatibility with current Requests/urllib3 releases
- keep APScheduler 3.7 compatible with Setuptools releases that still provide `pkg_resources`

## Context

The e2e workflow for #397 failed before starting Django because the existing `python-environ==0.4.54` distribution cannot be resolved. Keeping this build repair separate avoids mixing dependency maintenance into the #368 cleanup.

## Verification

- `git diff --check`
- the same dependency compatibility versions completed the repository's Python 3.10 e2e workflow in a recent CI run
- this PR's GitHub Actions run is the final clean-base verification
