### PR TITLE
ci: pin Black to project version

### DIFF
--- a/.github/workflows/lint-changed-files.yml
+++ b/.github/workflows/lint-changed-files.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black
+          pip install black==24.3.0
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
## Summary

- install Black 24.3.0 in `lint-changed-files`, matching the version pinned by the project
- prevent unrelated pull requests from failing whenever Black publishes a new formatting release

## Context

#393 passes formatting with the repository's declared Black 24.3.0 but fails because the workflow currently installs an unpinned newer release. The lint policy should be reproducible from `requirements.txt`.

## Verification

- `git diff --check`
- all Python files changed by #393 pass `black==24.3.0 --check`
