### PR TITLE
ci: run Django tests and migration checks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           cd hinghwa-dict-backend
           if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+      - name: Check migrations and run Django tests
+        run: |
+          cd hinghwa-dict-backend
+          python3 manage.py makemigrations --check --dry-run
+          python3 manage.py test
       - name: Start django service
         run: |
           cd hinghwa-dict-backend


### PR DESCRIPTION
## Summary

- fail CI when Django model changes are missing migrations
- run the repository's Django unit tests before starting the e2e service

## Context

The original #393 branch added a model field without a migration, but the existing workflow only exercised HTTP collections after generating migrations dynamically. Running `makemigrations --check --dry-run` and `manage.py test` makes schema consistency and focused regression tests enforceable.

## Verification

- `git diff --check`
- this PR's clean-base e2e run verifies the new commands before merge
