### PR TITLE
test(user): lock avatar deduplication contract

### DIFF
--- a/hinghwa-dict-backend/user/tests.py
+++ b/hinghwa-dict-backend/user/tests.py
@@ -1,3 +1,33 @@
-from django.test import TestCase
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import SimpleTestCase
+
+from utils.Upload import TRUSTED_AVATAR_HOSTS, uploadAvatar
+from utils.exception.types.not_found import NotFoundException
+
+
+class UploadAvatarDeduplicationTests(SimpleTestCase):
+    @patch("utils.Upload.download_file")
+    def test_trusted_avatar_urls_are_not_downloaded_again(self, download_file):
+        for host in TRUSTED_AVATAR_HOSTS:
+            avatar = f"https://{host}/avatars/existing.png"
+            with self.subTest(host=host):
+                self.assertEqual(uploadAvatar(7, avatar), avatar)
+
+        download_file.assert_not_called()
+
+    @patch("utils.Upload.download_file")
+    def test_external_avatar_is_downloaded_once(self, download_file):
+        download_file.return_value = "https://cos.edialect.top/files/avatar.png"
+
+        result = uploadAvatar(7, "https://example.com/avatar.png")
+
+        self.assertEqual(result, download_file.return_value)
+        download_file.assert_called_once()
+
+    @patch("utils.Upload.download_file", return_value=None)
+    def test_failed_external_avatar_download_has_explicit_error(self, download_file):
+        with self.assertRaisesMessage(NotFoundException, "头像上传失败"):
+            uploadAvatar(7, "https://example.com/missing.png")
+
+        download_file.assert_called_once()

--- a/hinghwa-dict-backend/utils/Upload.py
+++ b/hinghwa-dict-backend/utils/Upload.py
@@ -5,17 +5,18 @@ from utils.exception.types.not_found import NotFoundException
 from urllib.parse import urlparse
 
 
-def uploadAvatar(id, avatar, suffix="png"):
-    # TODO 除了默认图片外，其他照片的重复性判断
-    if avatar == "https://cos.edialect.top/website/默认头像.jpg":
-        return avatar
-    # get domain name of avatar url
-    if urlparse(avatar).netloc in [
+TRUSTED_AVATAR_HOSTS = frozenset(
+    {
         "api.pxm.edialect.top",
         "cos.edialect.top",
         "cos.test.edialect.top",
         "dummyimage.com",
-    ]:
+    }
+)
+
+
+def uploadAvatar(id, avatar, suffix="png"):
+    if urlparse(avatar).hostname in TRUSTED_AVATAR_HOSTS:
         return avatar
     time = timezone.now().__format__("%Y_%m_%d")
     filename = time + "_" + random_str(15) + "." + suffix


### PR DESCRIPTION
## Summary

- make the already-hosted avatar allowlist an explicit immutable contract
- use parsed hostnames for exact host matching
- remove the stale avatar deduplication TODO
- add tests proving trusted URLs are returned without download, external URLs download once, and failures stay explicit

## Verification

- Black 24.3.0
- Python bytecode compilation
- pull-request CI runs the new Django tests and full API regression suite

Fixes #313
