### PR TITLE
fix(storage): enforce upload size limits

### DIFF
--- a/hinghwa-dict-backend/HinghwaDict/settings.py
+++ b/hinghwa-dict-backend/HinghwaDict/settings.py
@@ -150,6 +150,7 @@ DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", "DEFAULT_DEFAULT_FROM_EMAIL")
 # 媒体图片下载到media/下
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+MAX_UPLOAD_SIZE = env.int("MAX_UPLOAD_SIZE", default=20 * 1024 * 1024)
 
 # 跨域访问设置
 CORS_ORIGIN_ALLOW_ALL = True

--- a/hinghwa-dict-backend/website/storage.py
+++ b/hinghwa-dict-backend/website/storage.py
@@ -6,6 +6,16 @@ from django.conf import settings
 from qcloud_cos import CosConfig, CosS3Client
 
 
+class FileTooLargeError(ValueError):
+    pass
+
+
+def validate_file_size(file):
+    max_size = settings.MAX_UPLOAD_SIZE
+    if file.size > max_size:
+        raise FileTooLargeError(f"文件不能超过 {max_size} 字节")
+
+
 def upload_file(path, key):
     config = CosConfig(
         Region=settings.COS_REGION,
@@ -33,18 +43,38 @@ def delete_file(key):
 
 
 def download_file(url, type, user_id, filename):
+    path = None
+    response = None
     try:
         folder = os.path.join(settings.MEDIA_ROOT, type, user_id)
         if not os.path.exists(folder):
             os.makedirs(folder)
         path = os.path.join(folder, filename)
-        response = requests.get(url)
+        response = requests.get(url, stream=True, timeout=(5, 30))
+        response.raise_for_status()
+        content_length = response.headers.get("Content-Length")
+        if content_length and int(content_length) > settings.MAX_UPLOAD_SIZE:
+            raise FileTooLargeError(f"文件不能超过 {settings.MAX_UPLOAD_SIZE} 字节")
+        downloaded = 0
         with open(path, "wb") as f:
-            f.write(response.content)
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                downloaded += len(chunk)
+                if downloaded > settings.MAX_UPLOAD_SIZE:
+                    raise FileTooLargeError(
+                        f"文件不能超过 {settings.MAX_UPLOAD_SIZE} 字节"
+                    )
+                f.write(chunk)
         key = f'files/{type}/{user_id}/{filename.replace("_", "/")}'
         url = upload_file(path, key)
         return url
     except Exception as e:
+        if path and os.path.exists(path):
+            os.remove(path)
         print("Error occurred when downloading file, error message:")
         print(e)
         return None
+    finally:
+        if response is not None:
+            response.close()

--- a/hinghwa-dict-backend/website/tests.py
+++ b/hinghwa-dict-backend/website/tests.py
@@ -1,10 +1,15 @@
+import os
+import tempfile
 from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import User
-from django.test import SimpleTestCase, TestCase
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
 
 from website.notification.utils import sendNotification
+from website.storage import download_file
 from website.utils import filterInOrder, random_str
+from website.views import files
 
 
 class WebsiteUtilityTests(SimpleTestCase):
@@ -51,3 +56,65 @@ class NotificationUtilityTests(TestCase):
         self.assertEqual(
             notify_send.call_args.kwargs["recipient"], [self.first_recipient]
         )
+
+
+class UploadLimitTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(MAX_UPLOAD_SIZE=5)
+    @patch("website.views.token_check")
+    def test_direct_upload_rejects_file_before_writing(self, token_check):
+        token_check.return_value = Mock(id=7)
+        upload = SimpleUploadedFile("large.png", b"123456", content_type="image/png")
+        request = self.factory.post("/files", {"file": upload}, HTTP_TOKEN="token")
+
+        response = files(request)
+
+        self.assertEqual(response.status_code, 413)
+
+    @override_settings(MAX_UPLOAD_SIZE=5)
+    @patch("website.storage.upload_file")
+    @patch("website.storage.requests.get")
+    def test_remote_download_rejects_large_content_length(
+        self, requests_get, upload_file
+    ):
+        response = Mock()
+        response.headers = {"Content-Length": "6"}
+        requests_get.return_value = response
+
+        with tempfile.TemporaryDirectory() as media_root, override_settings(
+            MEDIA_ROOT=media_root
+        ):
+            result = download_file(
+                "https://example.com/avatar.png", "download", "7", "avatar.png"
+            )
+
+        self.assertIsNone(result)
+        requests_get.assert_called_once_with(
+            "https://example.com/avatar.png", stream=True, timeout=(5, 30)
+        )
+        upload_file.assert_not_called()
+
+    @override_settings(MAX_UPLOAD_SIZE=5)
+    @patch("website.storage.upload_file")
+    @patch("website.storage.requests.get")
+    def test_remote_download_removes_partial_oversized_file(
+        self, requests_get, upload_file
+    ):
+        response = Mock()
+        response.headers = {}
+        response.iter_content.return_value = [b"123", b"456"]
+        requests_get.return_value = response
+
+        with tempfile.TemporaryDirectory() as media_root, override_settings(
+            MEDIA_ROOT=media_root
+        ):
+            result = download_file(
+                "https://example.com/avatar.png", "download", "7", "avatar.png"
+            )
+            path = os.path.join(media_root, "download", "7", "avatar.png")
+            self.assertFalse(os.path.exists(path))
+
+        self.assertIsNone(result)
+        upload_file.assert_not_called()

--- a/hinghwa-dict-backend/website/views.py
+++ b/hinghwa-dict-backend/website/views.py
@@ -19,7 +19,7 @@ from .forms import DailyExpressionForm
 from .models import Website, DailyExpression
 from .notification.dto import notification_normal
 from .notification.utils import sendNotification, readNotification
-from .storage import upload_file, delete_file
+from .storage import FileTooLargeError, upload_file, delete_file, validate_file_size
 from user.dto.user_simple import user_simple
 from .utils import (
     globalVar,
@@ -244,6 +244,12 @@ def files(request):
         if user:
             if request.method == "POST":
                 file = request.FILES.get("file")
+                if file is None:
+                    return JsonResponse({"msg": "缺少文件"}, status=400)
+                try:
+                    validate_file_size(file)
+                except FileTooLargeError as error:
+                    return JsonResponse({"msg": str(error)}, status=413)
                 type = str(file.content_type).split("/")[0]
                 if file._name.find(".") != -1:
                     suffix = file._name.rsplit(".")[-1]


### PR DESCRIPTION
## Summary

- add a configurable `MAX_UPLOAD_SIZE` (20 MiB default)
- reject oversized `/files` uploads before writing them to disk or COS
- stream remote avatar downloads with connect/read timeouts and enforce the same limit even without `Content-Length`
- remove partial oversized downloads and close HTTP responses reliably
- add tests for direct, declared-size, and streamed-size rejection paths

## Scope

This is the first independently deployable phase of #157. Per-user quotas, rate limiting, content/MIME verification, and SSRF controls remain tracked by that issue, so this PR intentionally does not close it.

## Verification

- Black 24.3.0
- Python bytecode compilation
- pull-request CI runs Django tests, migration checks, lint, and the full API suite

Refs #157
